### PR TITLE
Fix ADPCM encoder buffer overflow causing silent AWC build failure

### DIFF
--- a/Audiotool/Converters/WavConverter.cs
+++ b/Audiotool/Converters/WavConverter.cs
@@ -6,13 +6,20 @@ namespace Audiotool.Converters;
 
 public static class WavConverter
 {
+    // CodeWalker's ADPCMCodec.EncodeADPCM sizes its output buffer as data.Length / 4
+    // and processes in 8192-byte blocks. A partial tail block writes a 4-byte header
+    // past the end of the output buffer → IndexOutOfRangeException, swallowed by
+    // AwcFile.ReadXml's catch and surfacing later as a null-ref NRE in BuildPeakChunks.
+    // Padding the PCM data chunk to a multiple of 8192 bytes prevents the overflow.
+    private const int AdpcmBlockBytes = 8192;
+
     public static void ConvertToWav(List<Audio> audioFiles, string outputFolder)
     {
         foreach (Audio audio in audioFiles)
         {
             string outputPath = Path.Combine(outputFolder, $"{audio.FileName}.wav");
 
-            if (audio.FileExtension != "wav")
+            if (audio.FileExtension.TrimStart('.').ToLowerInvariant() != "wav")
             {
                 FFMpegArguments ff = FFMpegArguments
                     .FromFileInput(audio.FilePath);
@@ -33,7 +40,57 @@ public static class WavConverter
                 File.Copy(audio.FilePath, outputPath, true);
             }
 
+            PadPcmToBlockBoundary(outputPath, AdpcmBlockBytes);
+
             audio.FileSize = (ulong)new FileInfo(outputPath).Length;
+
+            int actualSamples = ComputeSampleCount(outputPath);
+            if (actualSamples > 0)
+                audio.Samples = actualSamples;
         }
+    }
+
+    private static int ComputeSampleCount(string wavPath)
+    {
+        byte[] wav = File.ReadAllBytes(wavPath);
+        (int dataOffset, int dataLen) = FindDataChunk(wav);
+        if (dataOffset < 0) return 0;
+        int bitsPerSample = wav.Length >= 36 ? BitConverter.ToInt16(wav, 34) : 16;
+        int channels = wav.Length >= 24 ? BitConverter.ToInt16(wav, 22) : 1;
+        int bytesPerSample = (bitsPerSample / 8) * Math.Max(channels, 1);
+        return bytesPerSample == 0 ? 0 : dataLen / bytesPerSample;
+    }
+
+    private static void PadPcmToBlockBoundary(string wavPath, int blockBytes)
+    {
+        byte[] wav = File.ReadAllBytes(wavPath);
+        (int dataTag, int dataLen) = FindDataChunk(wav);
+        if (dataTag < 0) return;
+
+        int pad = (blockBytes - (dataLen % blockBytes)) % blockBytes;
+        if (pad == 0) return;
+
+        int dataStart = dataTag + 8;
+        byte[] padded = new byte[wav.Length + pad];
+        Buffer.BlockCopy(wav, 0, padded, 0, dataStart + dataLen);
+        // trailing bytes stay zero-initialized (silence)
+
+        int newDataLen = dataLen + pad;
+        Buffer.BlockCopy(BitConverter.GetBytes(newDataLen), 0, padded, dataTag + 4, 4);
+
+        int riffLen = BitConverter.ToInt32(wav, 4) + pad;
+        Buffer.BlockCopy(BitConverter.GetBytes(riffLen), 0, padded, 4, 4);
+
+        File.WriteAllBytes(wavPath, padded);
+    }
+
+    private static (int tagOffset, int dataLength) FindDataChunk(byte[] wav)
+    {
+        for (int i = 12; i < wav.Length - 8; i++)
+        {
+            if (wav[i] == 'd' && wav[i + 1] == 'a' && wav[i + 2] == 't' && wav[i + 3] == 'a')
+                return (i, BitConverter.ToInt32(wav, i + 4));
+        }
+        return (-1, 0);
     }
 }

--- a/Audiotool/builders/AWCBuilder.cs
+++ b/Audiotool/builders/AWCBuilder.cs
@@ -45,6 +45,7 @@ public static class AWCBuilder
         GenerateNametable(outputPath, wavPath);
 
         int fails = 0;
+        Exception? lastEx = null;
 
         do
         {
@@ -59,14 +60,35 @@ public static class AWCBuilder
                     break;
                 }
             }
-            catch (Exception)
+            catch (Exception ex)
             {
+                lastEx = ex;
+                try
+                {
+                    string logPath = Path.Combine(outputPath, "awc_build_error.log");
+                    File.AppendAllText(logPath,
+                        $"[attempt {fails + 1}] {DateTime.Now:O}\n" +
+                        $"Type: {ex.GetType().FullName}\n" +
+                        $"Message: {ex.Message}\n" +
+                        $"StackTrace:\n{ex.StackTrace}\n" +
+                        (ex.InnerException != null
+                            ? $"Inner: {ex.InnerException.GetType().FullName}: {ex.InnerException.Message}\n{ex.InnerException.StackTrace}\n"
+                            : "") +
+                        "----\n");
+                }
+                catch { }
                 Thread.Sleep(1000);
                 fails++;
             }
         } while (fails < 5);
 
-        if (fails == 5)
+        if (fails == 5 && lastEx != null)
+        {
+            MessageBox.Show(
+                $"Failed after 5 attempts.\n\n{lastEx.GetType().Name}: {lastEx.Message}\n\nSee awc_build_error.log for full stack trace.",
+                "Unable to build AWC!");
+        }
+        else if (fails == 5)
         {
             MessageBox.Show("Failed to build AWC with Codewalker in 5 attempts! Please manually build", "Unable to build AWC!");
         }


### PR DESCRIPTION
## Problem

Building an AWC resource with certain audio files (especially 48 kHz sources or larger banks) silently fails — Audiotool retries 5 times then shows:

> Failed to build AWC with Codewalker in 5 attempts! Please manually build

No error details. The real exception is swallowed by the empty `catch (Exception)` in `BuildAWC`.

## Root cause

`CodeWalker.Core`'s `ADPCMCodec.EncodeADPCM` allocates its output buffer as `data.Length / 4` and processes input in **8192-byte blocks**. When the PCM `data` chunk is not a multiple of 8192 bytes, the final partial block writes a 4-byte block header past the end of the output buffer → `IndexOutOfRangeException`.

`AwcFile.ReadXml` catches that exception silently, leaving `DataChunk.Data` null. `BuildPeakChunks` then NREs on `data.Length`, which is what the user sees as "Object reference not set to an instance of an object".

## Fix

**`WavConverter.cs`** — after each WAV is written, pad the PCM `data` chunk to the next 8192-byte boundary with zero (silent) bytes before CodeWalker reads it. Also recomputes `audio.Samples` from the actual post-padding byte count so the generated `<Samples>` value in the XML stays accurate.

**`AWCBuilder.cs`** — replace the empty `catch (Exception)` with one that logs the full exception type, message, and stack trace to `awc_build_error.log` and shows the error text in the failure dialog. Silently swallowing the exception made every AWC build error impossible to diagnose.

## Testing

Verified against a 25-stream, 48 kHz audio bank that previously failed on every build attempt. After the fix it builds cleanly on the first try.